### PR TITLE
add Loggable trait

### DIFF
--- a/src/main/scala/org/fluentd/logger/scala/FluentLogger.scala
+++ b/src/main/scala/org/fluentd/logger/scala/FluentLogger.scala
@@ -28,6 +28,14 @@ case class FluentLogger(tag :String, sender: Sender) {
     else 
       sender.emit(tag + "." + label, data.toMap)
   }
+
+  def log(label: String, l: Loggable): Boolean = {
+    log(label, l.toRecord, 0)
+  }
+
+  def log(label: String, l: Loggable, timestamp: Long): Boolean = {
+    log(label, l.toRecord, timestamp)
+  }
   
   def flush() = sender.flush() 
   

--- a/src/main/scala/org/fluentd/logger/scala/Loggable.scala
+++ b/src/main/scala/org/fluentd/logger/scala/Loggable.scala
@@ -1,0 +1,5 @@
+package org.fluentd.logger.scala
+
+trait Loggable {
+  def toRecord: Map[String, Any]
+}

--- a/src/test/scala/org/fluentd/logger/scala/FluentLoggerSuite.scala
+++ b/src/test/scala/org/fluentd/logger/scala/FluentLoggerSuite.scala
@@ -159,6 +159,17 @@ class FluentLoggerSuite extends FunSuite with BeforeAndAfter {
     FluentLoggerFactory.closeAll
   }
 
+  test("test sending Loggable object") {
+    val logger0 = FluentLoggerFactory.getLogger("debug")
+    val ts = System.currentTimeMillis
+    val o = new Loggable {
+      def toRecord = Map("key" -> "value")
+    }
+    logger0.log("test01", o, ts);
+    FluentLoggerFactory.flushAll
+    FluentLoggerFactory.closeAll
+  }
+
   test("close") {
     FluentLoggerFactory.getLogger("tag1");
     FluentLoggerFactory.getLogger("tag2");


### PR DESCRIPTION
Any object which Loggable trait is mixed-in can be emitted.

Although this commits maintains original package tree, I think it should be changed.

How to:

``` scala
case class Foo(i: Int) extends Loggable {
  val tag = "Foo"

  def toEvent = Event(tag, System.currentTimeMillis, Map("i" -> i))
}

val f = Foo(1)
logger.log(f)

```
