### PR TITLE
Fix to return false if it exceeds the buffer capacity

### DIFF
--- a/src/main/scala/org/fluentd/logger/scala/sender/ScalaRawSocketSender.scala
+++ b/src/main/scala/org/fluentd/logger/scala/sender/ScalaRawSocketSender.scala
@@ -110,8 +110,7 @@ class ScalaRawSocketSender(h:String, p:Int, to:Int, bufCap:Int)
     try {
       // serialize tag, timestamp and data
       val json = Serialization.write(event)
-      send(json.getBytes("UTF-8"))
-      return true
+      return send(json.getBytes("UTF-8"))
     } catch {
       case e: IOException =>
         LOG.severe("Cannot serialize event: " + event);


### PR DESCRIPTION
Fix to return false if it exceeds the buffer capacity.

It was changed in the following commit.
https://github.com/fluent/fluent-logger-scala/commit/5d6b27271b89de8a90686a6e51a5f15bb486a273#diff-d443588ac9f0424891ef04ebcb7c5403R115